### PR TITLE
Create package.json to enable installation via MicroPython mip installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "urls": [
     ["picozero/__init__.py", "github:RaspberryPiFoundation/picozero/picozero/__init__.py"],
-    ["picozero/picozero.py", "github:RaspberryPiFoundation/picozero/picozero/picozero.py"],
+    ["picozero/picozero.py", "github:RaspberryPiFoundation/picozero/picozero/picozero.py"]
   ],
   "deps": [
   ],

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "urls": [
+    ["picozero/__init__.py", "github:RaspberryPiFoundation/picozero/picozero/__init__.py"],
+    ["picozero/picozero.py", "github:RaspberryPiFoundation/picozero/picozero/picozero.py"],
+  ],
+  "deps": [
+  ],
+  "version": "0.4.2"
+}


### PR DESCRIPTION
Micropython v1.20 (April 2023) comes with their **mip** installer tool for package maintenance.

Adding a trivial **package.json** file to the repo will enable installation of **picozero** by means of the **mip** installer.

[Note this PR is based off the main branch at v 0.4.1, which is behind the version available via PyPi.]
