### PR TITLE
Make max_distance in DistanceSensor a float

### DIFF
--- a/picozero/picozero.py
+++ b/picozero/picozero.py
@@ -1903,7 +1903,7 @@ class DistanceSensor(PinsMixin):
         close to measure) and 1 (maximum distance). This parameter specifies
         the maximum distance expected in meters. This defaults to 1.
     """
-    def __init__(self, echo, trigger, max_distance=1):
+    def __init__(self, echo, trigger, max_distance=1.0):
         self._pin_nums = (echo, trigger)
         self._max_distance = max_distance
         self._echo = Pin(echo, mode=Pin.IN, pull=Pin.PULL_DOWN)


### PR DESCRIPTION
Change the default value of max distance to a float, so that type checkers don't error when a float is used. This change will allow the documentation and the type checker to agree.

Originally:
<img width="704" height="68" alt="image" src="https://github.com/user-attachments/assets/e9902a21-adae-4973-9ad2-a2b89a562e94" />

After change:
<img width="721" height="163" alt="image" src="https://github.com/user-attachments/assets/5f70113e-f3d1-404c-8f8d-089fd32cda25" />
