### PR TITLE
Add missing documentation for MotionSensor class

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,11 @@ Change log
 
 .. currentmodule:: picozero
 
+0.5.0 - TBD
+-----------
+
++ Introduced ``MotionSensor`` class for PIR sensors
+
 0.4.2 - 2023-05-12
 ------------------
 

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -145,6 +145,17 @@ Turn the :obj:`pico_led` on when a :class:`Button` is pressed and off when it is
 
 .. literalinclude:: examples/button_led.py
 
+Motion sensor
+-------------
+
+Detect motion using a PIR (Passive Infrared) sensor:
+
+.. literalinclude:: examples/motion_sensor.py
+
+Use callbacks to respond to motion events:
+
+.. literalinclude:: examples/motion_sensor_callbacks.py
+
 RGB LEDs
 --------
 


### PR DESCRIPTION
Fixes #130

Adds missing documentation for the MotionSensor class that was merged in PR #126 but lacked documentation.

This is a documentation-only change to address missing docs for an already-merged feature.